### PR TITLE
Fix package name in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ To vendor ruby package into your release, run:
 ```
 $ git clone https://github.com/bosh-packages/ruby-release
 $ cd ~/workspace/your-release
-$ bosh vendor-package ruby-2.4 ~/workspace/ruby-release
+$ bosh vendor-package ruby-2.4-r3 ~/workspace/ruby-release
 ```
 
-The above code will add `ruby-2.4` to `your-release` and introduce a `spec.lock`.
+The above code will add `ruby-2.4-r3` to `your-release` and introduce a `spec.lock`.
 
 Included packages:
 
-- ruby-2.4 which includes:
+- ruby-2.4-r3 which includes:
   - ruby-2.4.2
   - yaml-0.1.7
   - bundler-1.15.3
@@ -27,7 +27,7 @@ To use `ruby-*` package for compilation in your packaging script:
 
 ```bash
 #!/bin/bash -eu
-source /var/vcap/packages/ruby-2.4/bosh/compile.env
+source /var/vcap/packages/ruby-2.4-r3/bosh/compile.env
 ...
 bosh_bundle
 bosh_generate_runtime_env
@@ -37,7 +37,7 @@ To use `ruby-*` package at runtime in your job scripts:
 
 ```bash
 #!/bin/bash -eu
-source /var/vcap/packages/ruby-2.4/bosh/runtime.env
+source /var/vcap/packages/ruby-2.4-r3/bosh/runtime.env
 source /var/vcap/packages/your-package/bosh/runtime.env
 bundle exec ...
 ```


### PR DESCRIPTION
Vendoring package `ruby-2.4` fails with `Expected to find package 'ruby-2.4'`; vendoring `ruby-2.4-r3` works as advertised.