### PR TITLE
bump rubygems to 3.2.x for ruby-2.7

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -146,7 +146,7 @@ jobs:
       resource: ruby-2.7
       trigger: true
     - get: rubygems
-      resource: rubygems-3.1
+      resource: rubygems-3.2
       trigger: true
     - get: yaml-0.1
       trigger: true
@@ -161,7 +161,7 @@ jobs:
     params:
       PRIVATE_YML: ((s3_private_yml))
       RUBY_VERSION: "2.7"
-      RUBYGEMS_VERSION: "3.1"
+      RUBYGEMS_VERSION: "3.2"
       LIBYAML_VERSION: "0.1"
   - task: test-bumped
     privileged: true
@@ -242,6 +242,33 @@ resources:
   type: dynamic-metalink
   source:
     version: "3.1.x"
+    version_check: |
+     git ls-remote --tags https://github.com/rubygems/rubygems.git \
+       | cut -f2 \
+       | grep -v '\^{}' \
+       | grep -E '^refs/tags/.+$' \
+       | sed  -E 's/^refs\/tags\/(.+)$/\1/'  \
+       | sed  's/^v//' \
+       | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'
+    metalink_get: |
+      export name="rubygems-${version}.tgz"
+      export url="https://rubygems.org/rubygems/rubygems-${version}.tgz"
+      export size=$( curl --silent --head "$url" | grep Content-Length | awk '{ print $2 }' | tr -cd '[:digit:]' )
+      jq -n '
+      {
+       "files": [
+        {
+         "name": env.name,
+         "urls": [ { "url": env.url } ],
+         "size": env.size | tonumber
+        }
+       ]
+      }'
+
+- name: rubygems-3.2
+  type: dynamic-metalink
+  source:
+    version: "3.2.x"
     version_check: |
      git ls-remote --tags https://github.com/rubygems/rubygems.git \
        | cut -f2 \


### PR DESCRIPTION
bumping the the rubygems to > 3.2.x
solves a rootless container issues that is trying to be solved in #19 

original issue https://github.com/rubygems/rubygems/issues/3977

fix is included in 3.2.3 see release notes https://github.com/rubygems/rubygems/releases/tag/v3.2.3
Includes this commit: https://github.com/rubygems/rubygems/pull/4065/commits/eb5b99b4d61ee00a17b44c0b795f38390d7b6398
