### PR TITLE
Patch libyaml to remove new behavior

### DIFF
--- a/packages/ruby-3.0.2-r0.65.0/packaging
+++ b/packages/ruby-3.0.2-r0.65.0/packaging
@@ -19,6 +19,8 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
   set -e
   cd "yaml-${LIBYAML_VERSION}"
 
+  patch -p1 < ../patches/libyaml-0.2.5.patch
+
   if [ "$(uname -m)" == "ppc64le" ]; then
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi

--- a/packages/ruby-3.0.2-r0.65.0/spec
+++ b/packages/ruby-3.0.2-r0.65.0/spec
@@ -11,3 +11,4 @@ files:
 - rubygems-3.2.28.tgz
 - runtime-3.0.2.env
 - yaml-0.2.5.tar.gz
+- patches/libyaml-0.2.5.patch

--- a/src/patches/libyaml-0.2.5.patch
+++ b/src/patches/libyaml-0.2.5.patch
@@ -1,0 +1,13 @@
+diff --git a/src/emitter.c b/src/emitter.c
+index 609b28a..05a11ef 100644
+--- a/src/emitter.c
++++ b/src/emitter.c
+@@ -663,7 +663,7 @@ yaml_emitter_emit_document_start(yaml_emitter_t *emitter,
+          * This can happen if a block scalar with trailing empty lines
+          * is at the end of the stream
+          */
+-        if (emitter->open_ended == 2)
++        if (0)
+         {
+             if (!yaml_emitter_write_indicator(emitter, "...", 1, 0, 0))
+                 return 0;


### PR DESCRIPTION
New versions of libyaml add a document end "..." when a document
has trailing newlines. This change in behavior breaks some bosh
releases that concat multiple yaml fragments within templates

This is currently a draft. These changes would be overwritten by the generation scripts but it should be pretty straight forward to modify the generation scripts to apply patches if they exist for the versions of the software we're using.