### PR TITLE
add ruby 3.1.x

### DIFF
--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -10,10 +10,14 @@ rubies:
 - version: "3.0"
   rubygems: "3.2"
   libyaml: "0.2"
+- version: "3.1"
+  rubygems: "3.3"
+  libyaml: "0.2"
 
 rubygems:
 - version: "3.1"
 - version: "3.2"
+- version: "3.3"
 
 libyamls:
 - version: "0.1"


### PR DESCRIPTION
add ruby 3.1.x
in preparation for moving bosh to ruby 3.1.0 
as ruby 3.1.0 supports `openssl 3`

the upcoming ubuntu-jammy runs on `openssl 3`