### PR TITLE
Experimental ruby 2.7.5 with openssl 3.0.0 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:jammy
+
+ADD https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.gz /tmp/ruby-2.7.5.tar.gz
+ADD https://github.com/ruby/openssl/archive/refs/tags/v3.0.0.tar.gz /tmp/openssl-3.0.0.tar.gz
+
+RUN apt-get update && apt-get install -y build-essential libssl-dev openssl libreadline-dev zlib1g-dev  # rsync
+
+RUN cd /tmp && \
+    tar -xf ruby-2.7.5.tar.gz && \
+    tar -xf openssl-3.0.0.tar.gz
+
+RUN cp -r /tmp/openssl-3.0.0/ext/openssl /tmp/ruby-2.7.5/ext/ && \
+    cp -r /tmp/openssl-3.0.0/lib /tmp/ruby-2.7.5/ext/openssl/
+
+RUN cd /tmp/ruby-2.7.5 && \
+    ./configure --with-openssl --with-openssl-dir=/usr/lib/ssl --disable-install-doc --without-gmp && \
+    make && \
+    make install

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,27 @@
+name: debug
+instance_groups:
+- azs: [az1]
+  instances: 1
+  jobs:
+  - name: ruby-2.7-test
+    release: ruby
+  name: debug
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: default
+releases:
+- name: ruby
+  version: latest
+variables:
+- name: ssh
+  type: ssh
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+update:
+  canaries: 2
+  canary_watch_time: 5000-60000
+  max_in_flight: 1
+  update_watch_time: 5000-60000

--- a/patch-ruby-2.7-openssl.sh
+++ b/patch-ruby-2.7-openssl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+dir=$(mktemp -d)
+
+mkdir -p "${dir}"
+pushd "${dir}"
+
+wget -O ruby-2.7.5.tar.gz https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.gz
+wget -O openssl-3.0.0.tar.gz https://github.com/ruby/openssl/archive/refs/tags/v3.0.0.tar.gz
+
+tar -xf ruby-2.7.5.tar.gz
+tar -xf openssl-3.0.0.tar.gz
+
+cp -r openssl-3.0.0/ext/openssl ruby-2.7.5/ext/
+cp -r openssl-3.0.0/lib ruby-2.7.5/ext/openssl/
+
+tar -czf ruby-2.7.5-openssl-3.0.0.tar.gz ruby-2.7.5
+
+popd
+
+bosh add-blob "${dir}/ruby-2.7.5-openssl-3.0.0.tar.gz" ruby-2.7.5.tar.gz
+
+rm -r "${dir}"


### PR DESCRIPTION
Since the [openssl gem](https://rubygems.org/gems/openssl/versions/3.0.0) states it support ruby version `>= 2.6.0` this PR attempts to upgrade the embedded openssl gem of ruby 2.7.5, to get it to compile on the Jammy stemcell.

This PR is not intended to be merged, but just a place to collect the research done around this topic.

<img width="723" alt="Screenshot 2022-02-01 at 16 13 21" src="https://user-images.githubusercontent.com/380697/151996806-3bf19306-b450-4b95-ac18-d367a3833076.png">

