### PR TITLE
Use Clang if available for Ruby 3.1+

### DIFF
--- a/ci/templates/packages/ruby/packaging.erb
+++ b/ci/templates/packages/ruby/packaging.erb
@@ -14,6 +14,11 @@ if [ $(uname -s) == "Darwin" ]; then
   fi
 fi
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 openssl_version=$(openssl version)
 openssl_major_version=$(echo "${openssl_version}" | cut -f2 -d\ | cut -f1 -d.)
 if [ "${openssl_major_version}" == 0 ]; then

--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -3,6 +3,11 @@
 # shellcheck disable=1090
 source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_packagename %>/bosh/runtime.env"
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 bosh_bundle() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'

--- a/packages/ruby-3.1/packaging
+++ b/packages/ruby-3.1/packaging
@@ -14,6 +14,11 @@ if [ $(uname -s) == "Darwin" ]; then
   fi
 fi
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 openssl_version=$(openssl version)
 openssl_major_version=$(echo "${openssl_version}" | cut -f2 -d\ | cut -f1 -d.)
 if [ "${openssl_major_version}" == 0 ]; then

--- a/src/compile-3.1.env
+++ b/src/compile-3.1.env
@@ -3,6 +3,11 @@
 # shellcheck disable=1090
 source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/ruby-3.1/bosh/runtime.env"
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 bosh_bundle() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'


### PR DESCRIPTION
The Clang compiler generates a smaller, faster Ruby than GCC on Jammy stemcells.

Specifically, the thread memory footprint is much smaller, from our notes:

- Jammy w/ GCC: 21688 initial, 32156 after thread, 32156 after finish, around 1MB per Thread.new call
- Jammy w/ Clang: 13932 initial, 14012 after thread, 14208 after finish, between 8KB and 28KB per Thread.new call

We only make this change for versions of Ruby 3.1 or greater. Ruby version 3.0 or lower won't compile with Jammy's OpenSSL 3.