### PR TITLE
removing hardcoded paths for ruby 3.1

### DIFF
--- a/packages/ruby-3.1/packaging
+++ b/packages/ruby-3.1/packaging
@@ -59,8 +59,8 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
 
 mkdir "${BOSH_INSTALL_TARGET}/bosh"
 cp gemrc "${BOSH_INSTALL_TARGET}/bosh/gemrc"
-cp compile-3.1.env "${BOSH_INSTALL_TARGET}/bosh/compile.env"
-cp runtime-3.1.env "${BOSH_INSTALL_TARGET}/bosh/runtime.env"
+envsubst '$BOSH_INSTALL_TARGET' <compile-3.1.env | tee "${BOSH_INSTALL_TARGET}/bosh/compile.env"
+envsubst '$BOSH_INSTALL_TARGET' <runtime-3.1.env | tee "${BOSH_INSTALL_TARGET}/bosh/runtime.env"
 
 source "${BOSH_INSTALL_TARGET}/bosh/runtime.env"
 

--- a/src/compile-3.1.env
+++ b/src/compile-3.1.env
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # shellcheck disable=1090
-source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/ruby-3.1/bosh/runtime.env"
+
+source "${BOSH_INSTALL_TARGET}/bosh/runtime.env"
 
 # Use Clang if available; the resulting Ruby is faster
 if [ -x /usr/bin/clang ]; then

--- a/src/runtime-3.1.env
+++ b/src/runtime-3.1.env
@@ -1,2 +1,2 @@
-export PATH="${BOSH_PACKAGES_DIR:-/var/vcap/packages}/ruby-3.1/bin:$PATH"
-export GEMRC="${BOSH_PACKAGES_DIR:-/var/vcap/packages}/ruby-3.1/bosh/gemrc"
+export PATH="${BOSH_INSTALL_TARGET}/bin:$PATH"
+export GEMRC="${BOSH_INSTALL_TARGET}/bosh/gemrc"


### PR DESCRIPTION
this is needed for our vendoring packages with a prefix. see https://github.com/cloudfoundry/bosh-cli/pull/603