### PR TITLE
Remove CFLAGS when compiling ruby

### DIFF
--- a/ci/templates/packages/ruby/packaging.erb
+++ b/ci/templates/packages/ruby/packaging.erb
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
   make
   make install
 )
@@ -58,7 +58,7 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
   make
   make install
 )

--- a/packages/ruby-3.1/packaging
+++ b/packages/ruby-3.1/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
   make
   make install
 )
@@ -58,7 +58,7 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
   make
   make install
 )

--- a/packages/ruby-3.2/packaging
+++ b/packages/ruby-3.2/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
   make
   make install
 )
@@ -58,7 +58,7 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
   make
   make install
 )

--- a/packages/ruby-3.3/packaging
+++ b/packages/ruby-3.3/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
   make
   make install
 )
@@ -58,7 +58,7 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
   make
   make install
 )

--- a/packages/ruby-3.4/packaging
+++ b/packages/ruby-3.4/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
   make
   make install
 )
@@ -58,7 +58,7 @@ tar xzf "ruby-${RUBY_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-install-doc --with-opt-dir="${BOSH_INSTALL_TARGET}" --without-gmp $with_openssl_dir
   make
   make install
 )


### PR DESCRIPTION
Bosh director template rendering runs about 2x as slow when the CFLAGS are specified and GCC is used.

This is likely due to the fact that when you specify CFLAGS, it removes the default "-O3" flag: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/408#issuecomment-2625120616

Since there isn't a clear reason why we are configuring "-fPIC" anyway, lets just remove them as we are planning on removing CLang from Noble stemcells and we'll be back to using GCC again.