### PR TITLE
remove --disable-shared flag

### DIFF
--- a/ci/templates/packages/ruby/packaging.erb
+++ b/ci/templates/packages/ruby/packaging.erb
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}"
   make
   make install
 )

--- a/packages/ruby-3.1/packaging
+++ b/packages/ruby-3.1/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}"
   make
   make install
 )

--- a/packages/ruby-3.2/packaging
+++ b/packages/ruby-3.2/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}"
   make
   make install
 )

--- a/packages/ruby-3.3/packaging
+++ b/packages/ruby-3.3/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}" 
   make
   make install
 )

--- a/packages/ruby-3.4/packaging
+++ b/packages/ruby-3.4/packaging
@@ -44,7 +44,7 @@ tar xzf "yaml-${LIBYAML_VERSION}.tar.gz"
     cp "${BOSH_COMPILE_TARGET}"/config/config.{guess,sub} ./tool
   fi
 
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --disable-shared
+  ./configure --prefix="${BOSH_INSTALL_TARGET}"
   make
   make install
 )


### PR DESCRIPTION
Based on discussions in #37, this PR removes the --disable-shared flag
Removing this flag also fixes issues that came with the removal of the CFLAGS in #37 while deploying bosh with create-env in nix based environments.

Pair: @fmoehler 