### PR TITLE
Add Ruby 4.0

### DIFF
--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -20,8 +20,11 @@ bosh_bundle() {
   bundle config set --local path "${BOSH_INSTALL_TARGET}/gem_home"
 
   bundle install \
-    --binstubs "${BOSH_INSTALL_TARGET}/bin" \
     "$@"
+
+  bundle binstubs \
+    --all \
+    --path "${BOSH_INSTALL_TARGET}/bin"
 }
 
 bosh_bundle_local() {
@@ -31,8 +34,11 @@ bosh_bundle_local() {
 
   bundle install \
     --local \
-    --binstubs "${BOSH_INSTALL_TARGET}/bin" \
     "$@"
+
+  bundle binstubs \
+    --all \
+    --path "${BOSH_INSTALL_TARGET}/bin"
 }
 
 bosh_generate_runtime_env() {

--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -13,11 +13,16 @@ rubies:
   rubygems: "3.6"
   libyaml: "0.2"
   stemcell: ubuntu-noble
+- version: "4.0"
+  rubygems: "4.0"
+  libyaml: "0.2"
+  stemcell: ubuntu-noble
 
 rubygems:
 - version: "3.4"
 - version: "3.5"
 - version: "3.6"
+- version: "4.0"
 
 libyamls:
 - version: "0.2"


### PR DESCRIPTION
Update: only CI changes are needed, files will be generated by bump

CI has been reconfigured but is failing because of:
```
+ bundle install --local --binstubs /var/vcap/packages/ruby-4.0-test/bin
The --binstubs option has been removed in favor of `bundle binstubs --all`
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/ruby-release/jobs/bump-4.0/builds/2#L69b8bf81:623:624

Changes to `compile.env.erb` to fix this are in this PR

Relevant info on deprecation of `bundle install --binstubs` is here:
https://blog.rubygems.org/2025/12/03/upgrade-to-rubygems-bundler-4.html