### PR TITLE
Fix ruby 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ New versions of RubyGems and libyaml must be added to the `rubygems` and `libyam
   stemcell: ubuntu-noble
 ```
 
+NOTE: please ensure that any commands used in `ci/templates/src/compile.env.erb` are compatible with the newly added Ruby / RubyGems version.
+
 ### Shared Concourse tasks
 
 This repository provides a couple helpful Concourse tasks in `ci/tasks/shared` that can help keep the Ruby package vendored in your BOSH release up to date, and bump gem versions.

--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -18,27 +18,22 @@ bosh_bundle() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'
   bundle config set --local path "${BOSH_INSTALL_TARGET}/gem_home"
+  bundle config set --local bin "${BOSH_INSTALL_TARGET}/bin"
 
-  bundle install \
-    "$@"
+  bundle install "$@"
 
-  bundle binstubs \
-    --all \
-    --path "${BOSH_INSTALL_TARGET}/bin"
+  bundle binstubs --all
 }
 
 bosh_bundle_local() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'
   bundle config set --local path "${BOSH_INSTALL_TARGET}/gem_home"
+  bundle config set --local bin "${BOSH_INSTALL_TARGET}/bin"
 
-  bundle install \
-    --local \
-    "$@"
+  bundle install --local "$@"
 
-  bundle binstubs \
-    --all \
-    --path "${BOSH_INSTALL_TARGET}/bin"
+  bundle binstubs --all
 }
 
 bosh_generate_runtime_env() {

--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -4,14 +4,14 @@
 source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/${PACKAGE_NAME}/bosh/runtime.env"
 
 # Use Clang if available; the resulting Ruby is faster
-if command -v clang &> /dev/null
-then
-  export CC="$(command -v clang)"
+if command -v clang &> /dev/null; then
+  CC="$(command -v clang)"
+  export CC
 fi
 
-if command -v clang++ &> /dev/null
-then
-  export CXX="$(command -v clang++)"
+if command -v clang++ &> /dev/null; then
+  CXX="$(command -v clang++)"
+  export CXX
 fi
 
 bosh_bundle() {

--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -26,14 +26,7 @@ bosh_bundle() {
 }
 
 bosh_bundle_local() {
-  bundle config set --local no_prune 'true'
-  bundle config set --local without 'development test'
-  bundle config set --local path "${BOSH_INSTALL_TARGET}/gem_home"
-  bundle config set --local bin "${BOSH_INSTALL_TARGET}/bin"
-
-  bundle install --local "$@"
-
-  bundle binstubs --all
+  bosh_bundle --local "$@"
 }
 
 bosh_generate_runtime_env() {


### PR DESCRIPTION
Fixes, hopefully the last, usage of Ruby 4.0 deprecated `bundle` commands/flags.

Addresses:
```
+ bundle binstubs --all --path /var/vcap/packages/ruby-4.0-test/bin
The `--path` flag has been removed because it relied on being remembered across
bundler invocations, which bundler no longer does. Instead please use `bundle
config set bin '/var/vcap/packages/ruby-4.0-test/bin'`, and stop using this flag
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/ruby-release/jobs/bump-4.0/builds/3#L69b8cb3f:645:648