### PR TITLE
Fix: rename variables from shell scripts used in ruby

### DIFF
--- a/ci/templates/jobs/ruby-test/spec.erb
+++ b/ci/templates/jobs/ruby-test/spec.erb
@@ -5,7 +5,7 @@ templates:
   run: bin/run
 
 packages:
-- <%= ruby_packagename %>
-- <%= test_packagename %>
+- <%= ruby_package_name %>
+- <%= test_package_name %>
 
 properties: {}

--- a/ci/templates/jobs/ruby-test/templates/run.erb
+++ b/ci/templates/jobs/ruby-test/templates/run.erb
@@ -7,7 +7,7 @@ ASSERT_GEM_VERSION="<%= rubygems_version %>"
 echo "Testing runtime compatibility"
 
 # shellcheck disable=1091
-source "/var/vcap/packages/<%= ruby_packagename %>/bosh/runtime.env"
+source "/var/vcap/packages/<%= ruby_package_name %>/bosh/runtime.env"
 ruby -e 'puts "test"'
 
 if [ $(ruby -e 'require "yaml"; puts({a: "b\n\n\n"}.to_yaml)' | grep "\.\.\.") ]; then
@@ -18,8 +18,8 @@ fi
 echo "Testing compile compatibility"
 
 # shellcheck disable=1091
-source "/var/vcap/packages/<%= test_packagename %>/bosh/runtime.env"
-cd "/var/vcap/packages/<%= test_packagename %>/"
+source "/var/vcap/packages/<%= test_package_name %>/bosh/runtime.env"
+cd "/var/vcap/packages/<%= test_package_name %>/"
 bundle exec puma &
 sleep 3
 curl http://localhost:3000 | grep test

--- a/ci/templates/packages/ruby-test/packaging.erb
+++ b/ci/templates/packages/ruby-test/packaging.erb
@@ -5,10 +5,10 @@ set -eux
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 
 # shellcheck disable=1090
-source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_packagename %>/bosh/compile.env"
+source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_package_name %>/bosh/compile.env"
 
 if [[ "${PLATFORM}" == "darwin" ]]; then
-  "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_packagename %>/bin/gem" install nokogiri
+  "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_package_name %>/bin/gem" install nokogiri
   exit 0
 fi
 

--- a/ci/templates/packages/ruby-test/spec.erb
+++ b/ci/templates/packages/ruby-test/spec.erb
@@ -1,8 +1,8 @@
 ---
-name: <%= test_packagename %>
+name: <%= test_package_name %>
 
 dependencies:
-- <%= ruby_packagename %>
+- <%= ruby_package_name %>
 
 files:
 - test-app/**/*

--- a/ci/templates/packages/ruby/spec.erb
+++ b/ci/templates/packages/ruby/spec.erb
@@ -1,5 +1,5 @@
 ---
-name: <%= ruby_packagename %>
+name: <%= ruby_package_name %>
 
 files:
 - compile-<%= ruby_version %>.env


### PR DESCRIPTION
Addresses:
```
+ erb ruby_blob=ruby-4.0.2.tar.gz ruby_version=4.0 ruby_patch_version=4.0.2 rubygems_blob=rubygems-4.0.8.tgz rubygems_version=4.0.8 yaml_blob=yaml-0.2.5.tar.gz yaml_version=0.2.5 test_package_name=ruby-4.0-test ruby_package_name=ruby-4.0 test_jobname=ruby-4.0-test ci/templates/packages/ruby/spec.erb
ci/templates/packages/ruby/spec.erb:2:in `<main>': undefined local variable or method `ruby_packagename' for main (NameError)
Did you mean?  ruby_package_name
```
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/ruby-release/jobs/bump-4.0/builds/5#L69b8cd90:124:126