### PR TITLE
Fix optional prefix_arg handling in bump-ruby-package.sh

### DIFF
--- a/ci/tasks/shared/bump-ruby-package.sh
+++ b/ci/tasks/shared/bump-ruby-package.sh
@@ -16,7 +16,7 @@ if [ -n "${PACKAGE_PREFIX}" ]; then
   prefix_arg="--prefix=${PACKAGE_PREFIX}"
 fi
 
-bosh vendor-package "${prefix_arg}" "${PACKAGE}" "$task_dir/ruby-release"
+bosh vendor-package ${prefix_arg:+"${prefix_arg}"} "${PACKAGE}" "$task_dir/ruby-release"
 
 package_version=$(cat "$task_dir/ruby-release/packages/${PACKAGE}/version")
 


### PR DESCRIPTION
The previous commit (076a1ca) added quotes around `${prefix_arg}` for shellcheck compliance. However, this breaks the script when `PACKAGE_PREFIX` is not set, because an empty string `""` gets passed as the first argument to `bosh vendor-package`, which rejects it.

Use `${prefix_arg:+"${prefix_arg}"}` to only pass the argument when it's non-empty, while still satisfying shellcheck.